### PR TITLE
refactor: removed the duplicate multi contract code

### DIFF
--- a/src/queries/distributor/useGetDividendShare.ts
+++ b/src/queries/distributor/useGetDividendShare.ts
@@ -1,6 +1,7 @@
+import { DistributorAbi } from "config";
 import { useMinimeConstants } from "queries";
 import { useGetWalletDetails } from "queries/walletDetails";
-import { useMultiCallContractDistributor } from "utils";
+import { useMultiCallContract } from "utils";
 
 type DistributorData = {
   totalShares: number;
@@ -21,7 +22,7 @@ export const useGetDividendShare = (): Result => {
   const { data: minimeConstants, isLoading, isError } = useMinimeConstants();
   const { data: userData } = useGetWalletDetails();
 
-  const distibutorUserData = useMultiCallContractDistributor(
+  const distibutorUserData = useMultiCallContract(
     "distributorUser",
     [
       {
@@ -29,12 +30,14 @@ export const useGetDividendShare = (): Result => {
         method: "shares",
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
         params: [userData?.address!],
+        abi: DistributorAbi,
       },
       {
         address: minimeConstants?.distributor,
         method: "getUnpaidEarnings",
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
         params: [userData?.address!],
+        abi: DistributorAbi,
       },
     ],
     {
@@ -43,16 +46,18 @@ export const useGetDividendShare = (): Result => {
     }
   );
 
-  const distibutorData = useMultiCallContractDistributor(
+  const distibutorData = useMultiCallContract(
     "distributor",
     [
       {
         address: minimeConstants?.distributor,
         method: "totalShares",
+        abi: DistributorAbi,
       },
       {
         address: minimeConstants?.distributor,
         method: "totalDistributed",
+        abi: DistributorAbi,
       },
     ],
     {
@@ -61,23 +66,18 @@ export const useGetDividendShare = (): Result => {
     }
   );
 
-  //TODO: fix type
-  let data: Partial<DistributorData> | undefined;
-  if (distibutorData.data) {
-    data = {
-      totalShares: distibutorData?.data[0],
-      totalDistributed: distibutorData?.data[1],
-    };
-  }
+  let data: DistributorData | undefined;
+
   if (distibutorUserData.data && distibutorData.data) {
     data = {
-      ...data,
-      shares: distibutorUserData?.data[0],
+      totalShares: distibutorData.data[0],
+      totalDistributed: distibutorData.data[1],
+      shares: distibutorUserData.data[0],
       sharePercentage:
-        (distibutorUserData?.data[0].split(",")[0] / distibutorData?.data[0]) *
+        (distibutorUserData.data[0].split(",")[0] / distibutorData.data[0]) *
         100,
-      claimedDividend: distibutorUserData?.data[0].split(",")[2],
-      unclaimedDividend: distibutorUserData?.data[1],
+      claimedDividend: distibutorUserData.data[0].split(",")[2],
+      unclaimedDividend: distibutorUserData.data[1],
     };
   }
 

--- a/src/utils/multicall/Batch/types.ts
+++ b/src/utils/multicall/Batch/types.ts
@@ -1,7 +1,10 @@
+import { type JsonFragment } from "@ethersproject/abi";
+
 export type QueryInfo = {
   address: string;
   method: string;
   params?: string[];
+  abi?: JsonFragment[];
 };
 
 export type Options = {

--- a/src/utils/multicall/index.ts
+++ b/src/utils/multicall/index.ts
@@ -1,7 +1,4 @@
 export { Batch } from "./Batch";
-export {
-  useMultiCallContract,
-  useMultiCallContractDistributor,
-} from "./useMultiCallContract";
+export { useMultiCallContract } from "./useMultiCallContract";
 
 export { type QueryInfo } from "./Batch";

--- a/src/utils/multicall/useMultiCallContract/index.ts
+++ b/src/utils/multicall/useMultiCallContract/index.ts
@@ -1,4 +1,1 @@
-export {
-  useMultiCallContract,
-  useMultiCallContractDistributor,
-} from "./useMultiCallContract";
+export { useMultiCallContract } from "./useMultiCallContract";

--- a/src/utils/multicall/useMultiCallContract/multicall.ts
+++ b/src/utils/multicall/useMultiCallContract/multicall.ts
@@ -1,6 +1,6 @@
 import { Contract, Provider } from "ethcall";
 
-import { DistributorAbi, ERC20Abi, METIS_RPC_URL } from "config";
+import { ERC20Abi, METIS_RPC_URL } from "config";
 import { ethers } from "ethers";
 import { QueryInfo } from "utils";
 
@@ -9,38 +9,14 @@ const provider = new ethers.providers.StaticJsonRpcProvider(METIS_RPC_URL);
 
 export const multicall = async (queryInfos: readonly QueryInfo[]) => {
   try {
-    const calls = queryInfos.map(({ address, method, params = [] }) => {
-      const contract = new Contract(address, ERC20Abi);
-      const balanceCall = contract[method](...params);
+    const calls = queryInfos.map(
+      ({ address, method, abi = ERC20Abi, params = [] }) => {
+        const contract = new Contract(address, abi);
+        const balanceCall = contract[method](...params);
 
-      return balanceCall;
-    });
-
-    await ethcallProvider.init(provider);
-
-    const data = await ethcallProvider?.all(calls);
-
-    // TODO: Is this formatting fine this way?
-    return data?.map((record: any) => record?.toString());
-  } catch (err) {
-    console.error(err);
-  }
-
-  return [];
-};
-
-// TODO: Remove this duplicate code. Added temporarily to have
-// multiple abi files.
-export const multicallDistributor = async (
-  queryInfos: readonly QueryInfo[]
-) => {
-  try {
-    const calls = queryInfos.map(({ address, method, params = [] }) => {
-      const contract = new Contract(address, DistributorAbi);
-      const balanceCall = contract[method](...params);
-
-      return balanceCall;
-    });
+        return balanceCall;
+      }
+    );
 
     await ethcallProvider.init(provider);
 

--- a/src/utils/multicall/useMultiCallContract/useMultiCallContract.ts
+++ b/src/utils/multicall/useMultiCallContract/useMultiCallContract.ts
@@ -2,17 +2,11 @@ import { useQuery } from "react-query";
 
 import { Batch, QueryInfo } from "utils";
 
-import { multicall, multicallDistributor } from "./multicall";
+import { multicall } from "./multicall";
 
-// TODO: Remove the duplicates here in batchLoader, multicontract hooks.
 const batchLoader = new Batch({
   batchSize: 20,
   multiCallFn: async (queryInfos) => multicall(queryInfos),
-});
-
-const batchLoaderDistributor = new Batch({
-  batchSize: 20,
-  multiCallFn: async (queryInfos) => multicallDistributor(queryInfos),
 });
 
 export type Options = {
@@ -36,22 +30,4 @@ export const useMultiCallContract = (
     select: options.select,
     enabled: options.enabled,
   });
-};
-
-export const useMultiCallContractDistributor = (
-  key: any,
-  queryInfo: QueryInfo | QueryInfo[],
-  options: Options = {}
-) => {
-  return useQuery(
-    [key, queryInfo],
-    () => batchLoaderDistributor.load(queryInfo),
-    {
-      refetchInterval: options.refetchInterval ?? 5_000,
-      staleTime: options.staleTime,
-      cacheTime: options.cacheTime,
-      select: options.select,
-      enabled: options.enabled,
-    }
-  );
 };


### PR DESCRIPTION
- Removed the code duplication which was introduced to pass the abi to the eth_call Provider.
- Now allowed the `abi` to be the part of the `QueryInfo` and its optional defaulted to `ERC20`