### PR TITLE
style: loading spinner for about us page and min-height for content area

### DIFF
--- a/src/components/AboutUs/AboutUs.tsx
+++ b/src/components/AboutUs/AboutUs.tsx
@@ -1,10 +1,10 @@
 import useResizeObserver from "beautiful-react-hooks/useResizeObserver";
-import { t } from "i18next";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Document, Page, pdfjs } from "react-pdf";
 
 import whitepaper from "assets/whitepaper.pdf";
+import { LoadingSpinner } from "components/LoadingSpinner";
 
 import { styles } from "./styles";
 
@@ -27,7 +27,11 @@ export const AboutUs: React.FC = () => {
           {t("downloadWhitepaper")}
         </a>
       </div>
-      <Document file={whitepaper} onLoadSuccess={handleDocumentLoadSuccess}>
+      <Document
+        loading={<LoadingSpinner />}
+        file={whitepaper}
+        onLoadSuccess={handleDocumentLoadSuccess}
+      >
         {Array.from(new Array(pageNumbers), (_, index) => (
           <Page
             width={parentRect?.width}

--- a/src/components/AboutUs/styles.ts
+++ b/src/components/AboutUs/styles.ts
@@ -11,7 +11,7 @@ export const styles = ({ color }: Theme) => css`
       color: ${color.text.white};
       padding: 10px;
       border-radius: 5px;
-      margin-bottom: 20px;
+      margin-bottom: 30px;
       display: inline-block;
       text-decoration: none;
       font-size: 20px;

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { t } from "i18next";
+import { useTranslation } from "react-i18next";
 
 import { useTheme } from "theme";
 
@@ -6,6 +6,7 @@ import { styles } from "./styles";
 
 export const Footer: React.FC = () => {
   const [theme] = useTheme();
+  const { t } = useTranslation();
 
   return (
     <div css={styles({ theme })}>

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -181,6 +181,10 @@ export const themeSwitchStyle =
       color: ${color.text.secondary};
       flex-shrink: 0;
 
+      @media (max-width: 1200px) {
+        color: ${color.text.primary};
+      }
+
       &::after {
         content: "";
         width: 35px;

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -7,7 +7,7 @@ export const Layout: React.FC = ({ children }) => {
   return (
     <div css={styles}>
       <Header />
-      <div className="container group">{children}</div>
+      <div className="container group main-content">{children}</div>
       <Footer />
     </div>
   );

--- a/src/components/Layout/styles.ts
+++ b/src/components/Layout/styles.ts
@@ -6,4 +6,8 @@ export const styles = css`
     margin: 0 auto;
     padding: 0 20px;
   }
+  .main-content {
+    // TODO: Find a better solution than hardcoding header and footer height
+    min-height: calc(100vh - 1072px); // 1072px = header + footer
+  }
 `;

--- a/src/pages/AboutUsPage.tsx
+++ b/src/pages/AboutUsPage.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import ReactMetaTags from "react-meta-tags";
 
-import { Layout } from "components/Layout";
 import { AboutUs } from "components/AboutUs";
+import { Layout } from "components/Layout";
 
 export const AboutUsPage: React.FC = () => {
   const { t } = useTranslation("aboutUs");


### PR DESCRIPTION
- loading spinner added instead of default loading text when loading whitepaper pdf
- styling fix for pushing footer down